### PR TITLE
chore(test): add Vitest + React Testing Library setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -79,7 +82,13 @@
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
-    "vite": "^5.4.19"
+    "vite": "^5.4.19",
+    "vitest": "^1.6.0",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.2",
+    "@testing-library/jest-dom": "^6.4.6",
+    "jsdom": "^24.0.0",
+    "@vitest/coverage-v8": "^1.6.0"
   },
   "overrides": {
     "@remix-run/router": "1.23.2"

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/src/smoke.test.tsx
+++ b/src/smoke.test.tsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+test('renders without crashing', () => {
+  function Hello() { return <div>App Mounted</div>; }
+  render(<Hello />);
+  expect(screen.getByText(/App Mounted/i)).toBeInTheDocument();
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react-swc';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/setupTests.ts'],
+    coverage: {
+      provider: 'v8',
+      reportsDirectory: './coverage',
+    },
+  },
+});


### PR DESCRIPTION
- Add Vitest + RTL with jsdom and jest-dom\n- vitest.config.ts + src/setupTests.ts\n- package.json scripts: test, test:watch, test:coverage\n- Sample test: src/smoke.test.tsx\n\nHow to run:\n- npm ci\n- npm run test\n- npm run test:watch (optional)\n- npm run test:coverage (optional)